### PR TITLE
Move Simple Analytics script injection to Vite config

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -87,9 +87,6 @@
     }
     </script>
 
-    <!-- 100% privacy-first analytics -->
-    <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
-    <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -2,6 +2,27 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-})
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    {
+      name: 'simpleanalytics',
+      transformIndexHtml(html) {
+        const file = mode === 'development' ? 'latest.dev.js' : 'latest.js';
+        return {
+          html,
+          tags: [
+            {
+              tag: 'script',
+              attrs: {
+                async: true,
+                src: `https://scripts.simpleanalyticscdn.com/${file}`
+              },
+              injectTo: 'head'
+            }
+          ],
+        };
+      },
+    },
+  ],
+}))


### PR DESCRIPTION
## Summary
Refactored the Simple Analytics script injection from static HTML to a dynamic Vite plugin configuration, enabling environment-specific script loading.

## Key Changes
- Converted `vite.config.js` from a static configuration object to a function that accepts the build mode
- Implemented a custom Vite plugin (`simpleanalytics`) that dynamically injects the analytics script into the HTML head during build
- Added environment-aware script selection: uses `latest.dev.js` in development mode and `latest.js` in production
- Removed the hardcoded analytics script tag and noscript fallback from `index.html`

## Implementation Details
- The plugin uses Vite's `transformIndexHtml` hook to inject the script tag with proper attributes (`async`, `src`)
- The script is injected into the `head` section via the `injectTo: 'head'` configuration
- This approach allows for cleaner HTML source while maintaining the same functionality across different build environments

https://claude.ai/code/session_014PfeKSFRcR4Y9PCxSsZwjf